### PR TITLE
Use the route's username in the query for tasks

### DIFF
--- a/feature_modules/TaskModule/TaskDataStore.ts
+++ b/feature_modules/TaskModule/TaskDataStore.ts
@@ -1,11 +1,12 @@
 import { Task } from '../../types/Task';
 import { TaskQuery } from '../../types/Query';
+import { UserIdentifier } from '../../types/User';
 
 export interface TaskDataStore {
-  getTask(taskId: string): Promise<Task>;
-  getTasks(query: TaskQuery): Promise<Task[]>;
+  getTask(taskId: string, author: string): Promise<Task>;
+  getTasks(query: TaskQuery, author: string): Promise<Task[]>;
 
   createTask(task: Partial<Task>): Promise<string>;
-  updateTask(task: Partial<Task>): Promise<void>;
-  deleteTask(taskId: string): Promise<void>;
+  updateTask(task: Partial<Task>, author: string): Promise<void>;
+  deleteTask(taskId: string, author: string): Promise<void>;
 }

--- a/feature_modules/TaskModule/TaskInteractor.ts
+++ b/feature_modules/TaskModule/TaskInteractor.ts
@@ -2,30 +2,35 @@ import { TaskDataStore } from "./TaskDataStore";
 import { Task } from "../../types/Task";
 import { TaskQuery } from "../../types/Query";
 import { TaskMongoDriver } from "./TaskMongoDriver";
+import { RequestErrorType } from "../../errors/Error";
 
 export class TaskInteractor {
   constructor(private dataStore: TaskDataStore = new TaskMongoDriver()) { }
 
-  async createTask(task: Partial<Task>): Promise<string> {
+  async createTask(task: Partial<Task>, author: string): Promise<string> {
+    if (task.author !== author) {
+      throw RequestErrorType.MISMATCHED_PROPERTY('The author of the task does not match the the username in the route.');
+    }
+
     const resultId = await this.dataStore.createTask(task);
     return resultId;
   }
   
-  async updateTask(task: Partial<Task>): Promise<void> {
-    await this.dataStore.updateTask(task);
+  async updateTask(task: Partial<Task>, author: string): Promise<void> {
+    await this.dataStore.updateTask(task, author);
   }
   
-  async getTask(taskId: string): Promise<Task> {
-    const task = await this.dataStore.getTask(taskId);
+  async getTask(taskId: string, author: string): Promise<Task> {
+    const task = await this.dataStore.getTask(taskId, author);
     return task;
   }
   
-  async deleteTask(taskId: string): Promise<void> {
-    await this.dataStore.deleteTask(taskId);
+  async deleteTask(taskId: string, author: string): Promise<void> {
+    await this.dataStore.deleteTask(taskId, author);
   }
   
-  async getTasks(query: TaskQuery): Promise<Task[]> {
-    const tasks = await this.dataStore.getTasks(query);
+  async getTasks(query: TaskQuery, author: string): Promise<Task[]> {
+    const tasks = await this.dataStore.getTasks(query, author);
     return tasks;
   }
 }

--- a/feature_modules/TaskModule/TaskModule.ts
+++ b/feature_modules/TaskModule/TaskModule.ts
@@ -30,7 +30,7 @@ export class TaskModule {
   @authorized(AccessGroup.ADMIN)
   @authenticated
   private async getTask(req: Request, res: Response) {
-    const task = await this.interactor.getTask(req.params.id);
+    const task = await this.interactor.getTask(req.params.id, req['user'].username);
     res.send(task);
   }
 
@@ -39,7 +39,7 @@ export class TaskModule {
   @authorized(AccessGroup.ADMIN)
   private async getTasks(req: Request, res: Response) {
     const query = CreateQuery.taskQueryFrom(req.query);
-    const tasks = await this.interactor.getTasks(query);
+    const tasks = await this.interactor.getTasks(query, req['user'].username);
     res.send(tasks);
   }
   @CatchRouteError(handleError)
@@ -56,7 +56,7 @@ export class TaskModule {
       throw Error.RequestErrorType.MISSING_PROPERTY('Must include a valid `task` object in the request body');
     }
 
-    const taskId = await this.interactor.createTask(Task.from(req.body.task));
+    const taskId = await this.interactor.createTask(Task.from(req.body.task), req['user'].username);
     res.status(201).json({ taskId });
   }
 
@@ -77,7 +77,7 @@ export class TaskModule {
     // if the above check passed, the task might not have an id property on it and it should be added manually
     task.id = req.params.id;
 
-    await this.interactor.updateTask(task);
+    await this.interactor.updateTask(task, req['user'].username);
     res.sendStatus(204);
   }
 
@@ -85,7 +85,7 @@ export class TaskModule {
   @authenticated
   @authorized(AccessGroup.ADMIN)
   private async deleteTask(req: Request, res: Response) {
-    await this.interactor.deleteTask(req.params.id);
+    await this.interactor.deleteTask(req.params.id, req['user'].username);
     res.sendStatus(204);
   }
 }

--- a/types/Task.ts
+++ b/types/Task.ts
@@ -1,17 +1,20 @@
 import { Insertable } from './generics/Insertable';
+import { UserIdentifier } from './User';
 
 export class Task extends Insertable {
   title: string;
+  author: string; // username;
   description?: string;
   date?: Date;
   completed: boolean = false;
   lastUpdated: Date;
 
   constructor();
-  constructor(id: string, title: string, lastUpdated: Date, description?: string, date?: Date, completed?: boolean);
-  constructor(id?: string, title?: string, lastUpdated?: Date, description?: string, date?: Date, completed?: boolean) {
+  constructor(id: string, author: string, title: string, lastUpdated: Date, description?: string, date?: Date, completed?: boolean);
+  constructor(id?: string, author?: string, title?: string, lastUpdated?: Date, description?: string, date?: Date, completed?: boolean) {
     super(id);
 
+    this.author = author;
     this.title = title;
     this.description = description;
     this.date = date;
@@ -36,6 +39,10 @@ export class Task extends Insertable {
 
     if (data.id) {
       t.id = data.id;
+    }
+
+    if (data.author) {
+      t.author = data.author;
     }
 
     if (data.title) {


### PR DESCRIPTION
This PR fixes a security hole where a user can obtain read/write permissions to tasks that don't belong to them simply by replacing the `:username` parameter of the route with their username. For example, if task `1` belongs to `username1` and a user with the username `username2` wants to access it, they can replace the intended route `users/username1/tasks/1` with `users/username2/tasks/1`. This occurred because the database queries were only using the tasks id to locate the task, not the author's username.